### PR TITLE
Improve stat progression curves and utilities

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+mod stat;
+mod table;
+
 use std::io;
 use std::io::Write;
 
@@ -61,7 +64,13 @@ impl Interface for StandardIoInterface {
     }
 }
 
-pub struct World;
+pub struct World {
+    pub player: Character,
+}
+
+pub struct Character {
+    stats: stat::StatBlock,
+}
 
 #[derive(Debug)]
 enum Summit {
@@ -154,7 +163,17 @@ fn exit<I: Interface>(mut interface: I, _world: World) -> ExitMarker {
 }
 
 fn main() {
-    let interface = StandardIoInterface {};
-    let world = World {};
+    let mut interface = StandardIoInterface {};
+    let mut world = World {
+        player: Character {
+            stats: stat::StatBlock::new(),
+        },
+    };
+    world
+        .player
+        .stats
+        .mut_stat(stat::StatKind::Strength)
+        .advance(1000);
+    interface.write(world.player.stats.print_table().as_str());
     enter(interface, world);
 }


### PR DESCRIPTION
There's now a method for performing a check and
gaining progression from doing so, with the progression
scaled based on a target difficulty as discussed.

I also switched progress to an exponential curve
that is sublinear for most of the levels characters
may have but gives a soft cap towards the end.

The new code has some unit tests and I put a struct
for the player in the world that has a stat block.