### PR TITLE
Story graph implementation

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -54,7 +54,7 @@ pub struct TestInterface {
 }
 
 impl TestInterface {
-    fn new(preset_choices: VecDeque<usize>) -> TestInterface {
+    pub fn new(preset_choices: VecDeque<usize>) -> TestInterface {
         TestInterface {
             written: String::new(),
             preset_choices,

--- a/src/story_graph.rs
+++ b/src/story_graph.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::choice::Choice;
 use crate::io::Interface;
 use crate::world::World;
 
@@ -81,14 +82,30 @@ impl StoryChoice {
         interface: &mut I,
         world: World,
     ) {
-        // TODO(amclees): Implement this function.
+        let chosen = interface.choose(self.options.clone());
+        if let Some(result_text) = chosen.result_text {
+            interface.write(result_text.as_str());
+        }
+        if let Some(next_node) = chosen.next_node {
+            let next_node = graph.get_node(next_node.as_str());
+            next_node.elements[0].run(0, next_node, graph, interface, world);
+        } else {
+            current_node.elements[index + 1].run(index + 1, current_node, graph, interface, world);
+        }
     }
 }
 
+#[derive(Clone)]
 pub struct StoryOption {
     intro_text: String,
     result_text: Option<String>,
     next_node: Option<String>,
+}
+
+impl Choice for StoryOption {
+    fn describe(&self) -> String {
+        self.intro_text.clone()
+    }
 }
 
 pub struct StoryText {
@@ -114,9 +131,7 @@ mod tests {
     use std::collections::VecDeque;
 
     use super::*;
-    use crate::character::Character;
     use crate::io::TestInterface;
-    use crate::stat::StatBlock;
     use crate::world::World;
 
     #[test]
@@ -139,15 +154,96 @@ mod tests {
         );
         let graph = StoryGraph::new();
         let mut interface = TestInterface::new(VecDeque::new());
-        let world = World {
-            player: Character {
-                stats: StatBlock::new(),
-            },
-        };
+        let world = World::empty();
         node.elements[0].run(0, &node, &graph, &mut interface, world);
         assert_eq!(
             interface.written,
             "Sample text.\nGoodbye! Thanks for playing."
+        );
+    }
+
+    #[test]
+    pub fn choices_without_a_next_node_run() {
+        let node = StoryNode::new(
+            "FooNode".to_string(),
+            vec![
+                StoryElement::Choice(StoryChoice {
+                    options: vec![
+                        StoryOption {
+                            intro_text: "Foo\n".to_string(),
+                            result_text: None,
+                            next_node: None,
+                        },
+                        StoryOption {
+                            intro_text: "Bar\n".to_string(),
+                            result_text: Some("Baz\n".to_string()),
+                            next_node: None,
+                        },
+                    ],
+                }),
+                StoryElement::Exit,
+            ],
+        );
+        let graph = StoryGraph::new();
+        let mut interface = TestInterface::new(VecDeque::from(vec![1, 0]));
+        let world = World::empty();
+        node.elements[0].run(0, &node, &graph, &mut interface, world);
+        assert_eq!(interface.written, "Baz\nGoodbye! Thanks for playing.");
+        interface.written.clear();
+        let world = World::empty();
+        node.elements[0].run(0, &node, &graph, &mut interface, world);
+        assert_eq!(interface.written, "Goodbye! Thanks for playing.");
+    }
+
+    #[test]
+    pub fn choices_with_a_next_node_run() {
+        let mut graph = StoryGraph::new();
+        graph.add_node(StoryNode::new(
+            "FooNode".to_string(),
+            vec![
+                StoryElement::Text(StoryText {
+                    text: "Choose Foo or Bar\n".to_string(),
+                }),
+                StoryElement::Choice(StoryChoice {
+                    options: vec![
+                        StoryOption {
+                            intro_text: "Foo\n".to_string(),
+                            result_text: Some("Chose Foo\n".to_string()),
+                            next_node: Some("FooNode".to_string()),
+                        },
+                        StoryOption {
+                            intro_text: "Bar\n".to_string(),
+                            result_text: None,
+                            next_node: Some("BarNode".to_string()),
+                        },
+                    ],
+                }),
+            ],
+        ));
+        graph.add_node(StoryNode::new(
+            "BarNode".to_string(),
+            vec![
+                StoryElement::Text(StoryText {
+                    text: "Reached Bar\n".to_string(),
+                }),
+                StoryElement::Exit,
+            ],
+        ));
+        let mut interface = TestInterface::new(VecDeque::from(vec![0, 0, 0, 1]));
+        let world = World::empty();
+        let node = graph.get_node("FooNode");
+        node.elements[0].run(0, node, &graph, &mut interface, world);
+        assert_eq!(
+            interface.written,
+            "Choose Foo or Bar
+Chose Foo
+Choose Foo or Bar
+Chose Foo
+Choose Foo or Bar
+Chose Foo
+Choose Foo or Bar
+Reached Bar
+Goodbye! Thanks for playing."
         );
     }
 }

--- a/src/story_graph.rs
+++ b/src/story_graph.rs
@@ -35,26 +35,34 @@ impl StoryNode {
             elements: Vec::new(),
         }
     }
+
+    pub fn new(name: String, elements: Vec<StoryElement>) -> StoryNode {
+        StoryNode { name, elements }
+    }
 }
 
-enum StoryElement {
+pub enum StoryElement {
     Text(StoryText),
     Choice(StoryChoice),
+    Exit,
 }
 
 impl StoryElement {
     fn run<I: Interface>(
         &self,
-        index: i64,
+        index: usize,
         current_node: &StoryNode,
         graph: &StoryGraph,
-        interface: I,
+        interface: &mut I,
         world: World,
     ) {
         match self {
             StoryElement::Text(text) => text.run(index, current_node, graph, interface, world),
             StoryElement::Choice(choice) => {
                 choice.run(index, current_node, graph, interface, world)
+            }
+            StoryElement::Exit => {
+                interface.write("Goodbye! Thanks for playing.");
             }
         }
     }
@@ -67,10 +75,10 @@ pub struct StoryChoice {
 impl StoryChoice {
     fn run<I: Interface>(
         &self,
-        index: i64,
+        index: usize,
         current_node: &StoryNode,
         graph: &StoryGraph,
-        interface: I,
+        interface: &mut I,
         world: World,
     ) {
         // TODO(amclees): Implement this function.
@@ -90,24 +98,56 @@ pub struct StoryText {
 impl StoryText {
     fn run<I: Interface>(
         &self,
-        index: i64,
+        index: usize,
         current_node: &StoryNode,
         graph: &StoryGraph,
-        interface: I,
+        interface: &mut I,
         world: World,
     ) {
-        // TODO(amclees): Implement this function.
+        interface.write(self.text.as_str());
+        current_node.elements[index + 1].run(index, current_node, graph, interface, world);
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use super::*;
+    use crate::character::Character;
+    use crate::io::TestInterface;
+    use crate::stat::StatBlock;
+    use crate::world::World;
 
     #[test]
     pub fn stores_nodes() {
         let mut graph = StoryGraph::new();
         graph.add_node(StoryNode::empty_node(String::from("FooNode")));
         assert_eq!(graph.get_node("FooNode").name, "FooNode");
+    }
+
+    #[test]
+    pub fn text_nodes_write_text() {
+        let node = StoryNode::new(
+            "FooNode".to_string(),
+            vec![
+                StoryElement::Text(StoryText {
+                    text: "Sample text.\n".to_string(),
+                }),
+                StoryElement::Exit,
+            ],
+        );
+        let graph = StoryGraph::new();
+        let mut interface = TestInterface::new(VecDeque::new());
+        let world = World {
+            player: Character {
+                stats: StatBlock::new(),
+            },
+        };
+        node.elements[0].run(0, &node, &graph, &mut interface, world);
+        assert_eq!(
+            interface.written,
+            "Sample text.\nGoodbye! Thanks for playing."
+        );
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,16 @@
 use crate::character::Character;
+use crate::stat::StatBlock;
 
 pub struct World {
     pub player: Character,
+}
+
+impl World {
+    pub fn empty() -> World {
+        World {
+            player: Character {
+                stats: StatBlock::new(),
+            },
+        }
+    }
 }


### PR DESCRIPTION
These changes implement the StoryGraph runtime, making it possible to run built story graphs. There's still plenty of additional functionality to add, templates being a big part, but this should be a start. Once the parser is ready, we should be able to create some basic example graphs that might even be interesting.